### PR TITLE
disable vagrant-vbguest plugin by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,4 +82,9 @@ Vagrant.configure(2) do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
   end
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+    config.vbguest.no_install = true
+    config.vbguest.no_remote = true
+  end
 end


### PR DESCRIPTION
I'm working thru the sample code for DevOps 2.0 and found it helpful to disable the vagrant-vbguest plugin by default.
