### PR TITLE
Fix issue with nginx ansible task to support Docker 1.12

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -25,7 +25,7 @@
     volumes: "{{ volumes }}"
     log_driver: syslog
     log_opt:
-      syslog-tag: nginx
+      tag: nginx
   when: log_to_syslog is defined
   tags: [nginx]
 


### PR DESCRIPTION
@vfarcic 

I just found this issue regarding syslog-tag has been deprecated in docker 1.12 so the following ansible playbook fails:

vagrant@cd:~$ ansible-playbook /vagrant/ansible/prod4.yml -i /vagrant/ansible/hosts/prod

Any recently Devops 2 book reader following it today (like me :D) will get docker >1.12 so this should fix this particular issue. Another solution would be to hardcode the docker version deployed thru the ansible provisioning steps.

@vfarcic Great book btw.
