### PR TITLE
Applying jinja format for ansible2

### DIFF
--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -3,7 +3,7 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: 0755
-  with_items: files
+  with_items: "{{ files }}"
   tags: [etcd]
 
 - name: Is running


### PR DESCRIPTION
 Error encounter when trying to provision etcd role to `serv-disc-0[1-3]` servers from `cd` server