### PR TITLE
Add NET_ADMIN capability to haproxy

### DIFF
--- a/ansible/roles/haproxy/tasks/main.yml
+++ b/ansible/roles/haproxy/tasks/main.yml
@@ -21,4 +21,5 @@
     state: running
     ports: "{{ ports }}"
     volumes: /data/haproxy/config/:/etc/haproxy/
+    cap_add: NET_ADMIN
   tags: [haproxy]


### PR DESCRIPTION
million12/haproxy requires NET_ADMIN since ead207ddf282ecf4b7503d28662601ea663fc030.

Add NET_ADMIN to cap_add to stop the warning:
"Please enable NET_ADMIN capabilities by passing '--cap-add NET_ADMIN' parameter to docker run command"