### PR TITLE
replacing state: running with state: started

### DIFF
--- a/ansible/roles/docker/tasks/centos.yml
+++ b/ansible/roles/docker/tasks/centos.yml
@@ -18,6 +18,6 @@
 - name: CentOS service is running
   service:
     name: docker
-    state: running
+    state: started
   tags: [docker]
 

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -2,7 +2,7 @@
   docker_container:
     name: elasticsearch
     image: elasticsearch:2
-    state: running
+    state: started
     ports:
       - 9200:9200
     volumes:

--- a/ansible/roles/haproxy/tasks/main.yml
+++ b/ansible/roles/haproxy/tasks/main.yml
@@ -18,7 +18,7 @@
   docker_container:
     image: million12/haproxy
     name: haproxy
-    state: running
+    state: started
     ports: "{{ ports }}"
     volumes: /data/haproxy/config/:/etc/haproxy/
     cap_add: NET_ADMIN

--- a/ansible/roles/logstash/tasks/main.yml
+++ b/ansible/roles/logstash/tasks/main.yml
@@ -18,7 +18,7 @@
   docker_container:
     name: logstash
     image: logstash:2
-    state: running
+    state: started
     hostname: "{{ ansible_hostname }}"
     expose:
       - 5044

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -10,7 +10,7 @@
   docker_container:
     image: nginx:alpine
     name: nginx
-    state: running
+    state: started
     ports: "{{ ports }}"
     volumes: "{{ volumes }}"
   when: not log_to_syslog is defined
@@ -20,7 +20,7 @@
   docker_container:
     image: nginx:alpine
     name: nginx
-    state: running
+    state: started
     ports: "{{ ports }}"
     volumes: "{{ volumes }}"
     log_driver: syslog


### PR DESCRIPTION
As per https://disqus.com/home/discussion/channel-thedevops20toolkit/deprecated_ansible_modules_with_ansible_250/ and http://docs.ansible.com/ansible/latest/service_module.html with the recent Ansible upgrade `state: running` doesn't work anymore when running ansible-playbook from the CD server. 